### PR TITLE
Fix account activation callout on the registration page

### DIFF
--- a/templates/core/accounts/register.html
+++ b/templates/core/accounts/register.html
@@ -81,7 +81,7 @@
                         </div>
                         <div class="callout">
                             <h3><i class="fa fa-info-circle"></i> Account Activation Required!</h3>
-                            <p>After clicking the Registration button below, you will receive an activation email. 
+                            <p>After clicking the Register button below, you will receive an activation email. 
                                 <em>You must click the link in this email</em> to verify your account before logging in.</p>
                         </div>
                         <p>


### PR DESCRIPTION
Change the description of the Register button in the callout on the registration page